### PR TITLE
feat: minimal bitblasting implementation

### DIFF
--- a/LeanSAT/Reflect.lean
+++ b/LeanSAT/Reflect.lean
@@ -20,3 +20,4 @@ import LeanSAT.Reflect.Fin
 import LeanSAT.Reflect.Glue
 import LeanSAT.Reflect.BVExpr.Basic
 import LeanSAT.Reflect.BVExpr.BitBlast
+import LeanSAT.Reflect.Tactics.BVDecide

--- a/LeanSAT/Reflect.lean
+++ b/LeanSAT/Reflect.lean
@@ -18,3 +18,5 @@ import LeanSAT.Reflect.Tactics.SatCheck
 import LeanSAT.Reflect.Tactics.SatTrace
 import LeanSAT.Reflect.Fin
 import LeanSAT.Reflect.Glue
+import LeanSAT.Reflect.BVExpr.Basic
+import LeanSAT.Reflect.BVExpr.BitBlast

--- a/LeanSAT/Reflect/BVExpr/Basic.lean
+++ b/LeanSAT/Reflect/BVExpr/Basic.lean
@@ -80,18 +80,22 @@ end BVExpr
 
 inductive BVBinPred where
 | eq
+| neq
 
 namespace BVBinPred
 
 def toString : BVBinPred → String
   | eq => "=="
+  | neq => "!="
 
 instance : ToString BVBinPred := ⟨toString⟩
 
 def eval : BVBinPred → (BitVec w → BitVec w → Bool)
   | .eq => (· == ·)
+  | .neq => (· != ·)
 
 @[simp] theorem eval_eq : eval .eq = ((· == ·) : BitVec w → BitVec w → Bool) := by rfl
+@[simp] theorem eval_neq : eval .neq = ((· != ·) : BitVec w → BitVec w → Bool) := by rfl
 
 end BVBinPred
 

--- a/LeanSAT/Reflect/BVExpr/Basic.lean
+++ b/LeanSAT/Reflect/BVExpr/Basic.lean
@@ -3,11 +3,7 @@ Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Henrik Böving
 -/
-import Std.Data.BitVec.Basic
 import LeanSAT.Reflect.BoolExpr.Basic
-
-
-open Std
 
 inductive BVBinOp where
 | and

--- a/LeanSAT/Reflect/BVExpr/Basic.lean
+++ b/LeanSAT/Reflect/BVExpr/Basic.lean
@@ -48,7 +48,7 @@ inductive BVExpr (w : Nat) where
 namespace BVExpr
 
 def toString : BVExpr w → String
-  | .var idx => ToString.toString idx
+  | .var idx => s!"var{idx}"
   | .const val => ToString.toString val
   | .bin lhs op rhs => s!"({lhs.toString} {op.toString} {rhs.toString})"
   | .un op operand => s!"({op.toString} {toString operand})"

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -69,7 +69,7 @@ def bitblast (expr : BVPred) : BVBitwise :=
   | @bin w lhs op rhs =>
     match op with
     | .eq => goEq lhs rhs w (by omega)
-    | .neq => sorry
+    | .neq => .not (goEq lhs rhs w (by omega))
 where
   mkEqBit {w : Nat} (lhs rhs : BVExpr w) (bit : Nat) (h : bit < w) : BVBitwise :=
     let blhs := lhs.bitblast ⟨bit, h⟩
@@ -79,24 +79,24 @@ where
   goEq {w : Nat} (lhs rhs : BVExpr w) (bit : Nat) (h : bit ≤ w) :=
     match h:bit with
     | 0 => .const true
-    | rem + 1 => 
+    | rem + 1 =>
       let eq := mkEqBit lhs rhs rem (by omega)
       .gate .and eq (goEq lhs rhs rem (by omega))
 
-theorem bitblast.mkEqBit_correct (idx : Fin w) : 
-    (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign 
+theorem bitblast.mkEqBit_correct (idx : Fin w) :
+    (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign
       =
     ((lhs.eval assign).getLsb idx.val = (rhs.eval assign).getLsb idx.val) := by
   simp[mkEqBit, Gate.eval, BVExpr.getLsb_eq_bitblast]
 
 
-theorem bitblast.mkEqBit_correct' : 
+theorem bitblast.mkEqBit_correct' :
     (∀ (idx : Fin w), (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign)
-      = 
+      =
     (lhs.eval assign = rhs.eval assign) := by
   simp only [eq_iff_iff]
   constructor
-  . intro h; 
+  . intro h;
     apply BitVec.eq_of_getLsb_eq
     intro idx
     rw [← bitblast.mkEqBit_correct]
@@ -118,14 +118,14 @@ theorem Fin.forall_succ (p : Fin (n + 1) → Prop) [DecidablePred p] :
 
 theorem bitblast.aux :
    (∀ (idx : Fin w), (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign)
-     = 
+     =
    (goEq lhs rhs w (by omega)).eval assign := by
   induction w with
-  | zero => 
+  | zero =>
     simp[goEq]
     intro idx
     cases idx.isLt
-  | succ w ih => 
+  | succ w ih =>
     simp only [goEq, BVBitwise.eval_gate, Gate.eval, Bool.and_eq_true, eq_iff_iff]
     constructor
     . intro h

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -103,6 +103,18 @@ theorem bitblast.mkEqBit_correct' :
   . intro h idx
     simp [bitblast.mkEqBit_correct, h]
 
+theorem Fin.forall_succ (p : Fin (n + 1) → Prop) [DecidablePred p] :
+    (∀ (x : Fin (n + 1)), p x) ↔ (p (Fin.last _) ∧ ∀ (x : Fin n), p (x.castAdd 1)) :=
+  ⟨fun w => ⟨w _, fun i => w _⟩, fun ⟨h, w⟩ x =>
+    if p : x = Fin.last _ then by
+      subst p; exact h
+    else by
+      -- This line is needed now that `omega` doesn't check defeq on atoms.
+      simp [Fin.last, ← Fin.val_ne_iff] at p
+      have t : x < n := by omega
+      rw [show x = Fin.castAdd 1 ⟨x, by omega⟩ by rfl]
+      apply w⟩
+
 theorem bitblast.aux :
    (∀ (idx : Fin w), (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign)
      = 
@@ -118,11 +130,19 @@ theorem bitblast.aux :
     . intro h
       constructor
       . apply h ⟨w, (by omega)⟩
-      -- TODO: this follows from the ih but I don't quite know how
-      . sorry
-    . intro h idx
+      . rw [Fin.forall_succ] at h
+        rcases h with ⟨h1, h2⟩
+        -- TODO: this is almost IH now
+        sorry
+    . intro h
+      rw [Fin.forall_succ]
       rcases h with ⟨h1, h2⟩
-      sorry
+      constructor
+      . simp[h1]
+      . intro x
+        simp only [Fin.coe_castAdd]
+        -- TODO: this is almost IH now
+        sorry
 
 theorem bitblast.goEq_correct' {lhs rhs : BVExpr w} :
     ((goEq lhs rhs w (by omega)).eval assign)

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -17,9 +17,9 @@ abbrev BVBitwise := BoolExpr BVBit
 namespace BVBitwise
 
 def eval (assign : BVExpr.Assignment) (expr : BVBitwise) : Bool :=
-  BoolExpr.eval (fun bit => assign bit.var |>.snd.getLsb bit.idx.val) expr
+  BoolExpr.eval (fun bit => assign.getD bit.var |>.bv.getLsb bit.idx.val) expr
 
-@[simp] theorem eval_literal : eval assign (.literal bit) = (assign bit.var |>.snd.getLsb bit.idx.val) := rfl
+@[simp] theorem eval_literal : eval assign (.literal bit) = (assign.getD bit.var |>.bv.getLsb bit.idx.val) := rfl
 @[simp] theorem eval_const : eval assign (.const b) = b := rfl
 @[simp] theorem eval_not : eval assign (.not x) = !eval assign x := rfl
 @[simp] theorem eval_gate : eval assign (.gate g x y) = g.eval (eval assign x) (eval assign y) := rfl

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -1,0 +1,182 @@
+import Std.Data.Fin.Basic
+import Std.Data.BitVec.Lemmas
+import LeanSAT.Reflect.BVExpr.Basic
+
+open Std
+
+structure BVBit where
+  {w : Nat}
+  var : Nat
+  idx : Fin w
+
+instance : ToString BVBit where
+  toString b := s!"x{b.var}[{b.idx.val}]"
+
+abbrev BVBitwise := BoolExpr BVBit
+
+namespace BVBitwise
+
+def eval (assign : BVExpr.Assignment) (expr : BVBitwise) : Bool :=
+  BoolExpr.eval (fun bit => assign bit.var |>.snd.getLsb bit.idx.val) expr
+
+@[simp] theorem eval_literal : eval assign (.literal bit) = (assign bit.var |>.snd.getLsb bit.idx.val) := rfl
+@[simp] theorem eval_const : eval assign (.const b) = b := rfl
+@[simp] theorem eval_not : eval assign (.not x) = !eval assign x := rfl
+@[simp] theorem eval_gate : eval assign (.gate g x y) = g.eval (eval assign x) (eval assign y) := rfl
+
+def sat (x : BVBitwise) (assign : BVExpr.Assignment) : Prop := eval assign x = true
+def unsat (x : BVBitwise) : Prop := ∀ f, eval f x = false
+
+end BVBitwise
+
+namespace BVExpr
+
+def bitblast (expr : BVExpr w) (idx : Fin w) : BVBitwise :=
+  match expr with
+  | .var varIdx => .literal ⟨varIdx, idx⟩
+  | .const val => .const (val.getLsb idx.val)
+  | .bin lhs op rhs =>
+    match op with
+    | .and =>
+      let lhs := bitblast lhs idx
+      let rhs := bitblast rhs idx
+      .gate .and lhs rhs
+  | .un op operand =>
+    match op with
+    | .not =>
+      let operand := bitblast operand idx
+      .not operand
+
+theorem getLsb_eq_bitblast (expr : BVExpr w) (idx : Fin w) :
+    ∀ assign, (expr.eval assign).getLsb idx.val = (expr.bitblast idx).eval assign := by
+  intro assign
+  induction expr with
+  | var varIdx => simp [bitblast]
+  | const bv => simp [bitblast]
+  | bin lhs op rhs lih rih =>
+    cases op with
+    | and => simp[bitblast, Gate.eval, lih, rih]
+  | un op operand ih =>
+    cases op with
+    | not => simp[ih, bitblast]
+
+end BVExpr
+
+namespace BVPred
+
+def bitblast (expr : BVPred) : BVBitwise :=
+  match expr with
+  | @bin w lhs op rhs =>
+    match op with
+    | .eq => goEq lhs rhs w (by omega)
+where
+  mkEqBit {w : Nat} (lhs rhs : BVExpr w) (bit : Nat) (h : bit < w) : BVBitwise :=
+    let blhs := lhs.bitblast ⟨bit, h⟩
+    let brhs := rhs.bitblast ⟨bit, h⟩
+    .gate .beq blhs brhs
+
+  goEq {w : Nat} (lhs rhs : BVExpr w) (bit : Nat) (h : bit ≤ w) :=
+    match h:bit with
+    | 0 => .const true
+    | rem + 1 => 
+      let eq := mkEqBit lhs rhs rem (by omega)
+      .gate .and eq (goEq lhs rhs rem (by omega))
+
+theorem bitblast.mkEqBit_correct (idx : Fin w) : 
+    (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign 
+      =
+    ((lhs.eval assign).getLsb idx.val = (rhs.eval assign).getLsb idx.val) := by
+  simp[mkEqBit, Gate.eval, BVExpr.getLsb_eq_bitblast]
+
+
+theorem bitblast.mkEqBit_correct' : 
+    (∀ (idx : Fin w), (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign)
+      = 
+    (lhs.eval assign = rhs.eval assign) := by
+  simp only [eq_iff_iff]
+  constructor
+  . intro h; 
+    apply BitVec.eq_of_getLsb_eq
+    intro idx
+    rw [← bitblast.mkEqBit_correct]
+    apply h
+  . intro h idx
+    simp [bitblast.mkEqBit_correct, h]
+
+theorem bitblast.aux :
+   (∀ (idx : Fin w), (bitblast.mkEqBit lhs rhs idx.val idx.isLt).eval assign)
+     = 
+   (goEq lhs rhs w (by omega)).eval assign := by
+  induction w with
+  | zero => 
+    simp[goEq]
+    intro idx
+    cases idx.isLt
+  | succ w ih => 
+    simp only [goEq, BVBitwise.eval_gate, Gate.eval, Bool.and_eq_true, eq_iff_iff]
+    constructor
+    . intro h
+      constructor
+      . apply h ⟨w, (by omega)⟩
+      -- TODO: this follows from the ih but I don't quite know how
+      . sorry
+    . intro h idx
+      rcases h with ⟨h1, h2⟩
+      sorry
+
+theorem bitblast.goEq_correct' {lhs rhs : BVExpr w} :
+    ((goEq lhs rhs w (by omega)).eval assign)
+      ↔
+    ((BVPred.bin lhs .eq rhs).eval assign) := by
+  rw [← bitblast.aux]
+  rw [bitblast.mkEqBit_correct']
+  simp
+
+-- TODO: unclear how to get from ' to here
+theorem bitblast.goEq_correct {lhs rhs : BVExpr w} :
+    ((goEq lhs rhs w (by omega)).eval assign)
+      =
+    ((BVPred.bin lhs .eq rhs).eval assign) := by
+  sorry
+
+theorem eq_bitblast (expr : BVPred) : ∀ assign, expr.eval assign = expr.bitblast.eval assign := by
+  intro assign
+  cases expr with
+  | @bin w lhs op rhs =>
+    cases op with
+    | eq => simp [bitblast, bitblast.goEq_correct]
+
+end BVPred
+
+namespace BVLogicalExpr
+
+def bitblast (expr : BVLogicalExpr) : BVBitwise :=
+  match expr with
+  | .literal pred => pred.bitblast
+  | .gate g x y => .gate g (bitblast x) (bitblast y)
+  | .not x => .not (bitblast x)
+  | .const b => .const b
+
+theorem eq_bitblast (expr : BVLogicalExpr) : ∀ assign, expr.eval assign = expr.bitblast.eval assign := by
+  intro assign
+  induction expr with
+  | literal pred => simp[bitblast, BVPred.eq_bitblast]
+  | gate g lhs rhs lih rih => simp[bitblast, lih, rih]
+  | not op ih => simp[bitblast, ih]
+  | const b => simp[bitblast]
+
+theorem unsat_iff_bitblast_unsat (expr : BVLogicalExpr) : expr.unsat ↔ expr.bitblast.unsat := by
+  constructor
+  . intro h assign
+    rw[← eq_bitblast]
+    apply h
+  . intro h assign
+    rw [eq_bitblast]
+    apply h
+
+end BVLogicalExpr
+
+open BitVec
+#eval
+  let pred : BVLogicalExpr := .literal (.bin (.bin (w := 2) (.var 1) .and (.var 0)) .eq (.bin (.var 0) .and (.var 1)))
+  toString pred.bitblast

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -69,6 +69,7 @@ def bitblast (expr : BVPred) : BVBitwise :=
   | @bin w lhs op rhs =>
     match op with
     | .eq => goEq lhs rhs w (by omega)
+    | .neq => sorry
 where
   mkEqBit {w : Nat} (lhs rhs : BVExpr w) (bit : Nat) (h : bit < w) : BVBitwise :=
     let blhs := lhs.bitblast ⟨bit, h⟩
@@ -165,6 +166,7 @@ theorem eq_bitblast (expr : BVPred) : ∀ assign, expr.eval assign = expr.bitbla
   | @bin w lhs op rhs =>
     cases op with
     | eq => simp [bitblast, bitblast.goEq_correct]
+    | neq => sorry
 
 end BVPred
 

--- a/LeanSAT/Reflect/Tactics/Attr.lean
+++ b/LeanSAT/Reflect/Tactics/Attr.lean
@@ -8,3 +8,4 @@ import Lean.Util.Trace
 open Lean
 
 initialize registerTraceClass `sat
+initialize registerTraceClass `bv

--- a/LeanSAT/Reflect/Tactics/BVDecide.lean
+++ b/LeanSAT/Reflect/Tactics/BVDecide.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2024 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Henrik Böving
+-/
+import LeanSAT.Reflect.BVExpr.Basic
+import LeanSAT.Reflect.Tactics.SatDecide
+
+open Lean Meta
+
+namespace BVDecide
+
+-- TODO: This should be upstream?
+instance : ToExpr (Std.BitVec w) where
+  toExpr bv := mkApp2 (mkConst ``Std.BitVec.ofNat) (toExpr w) (toExpr bv.toNat)
+  toTypeExpr := mkApp (mkConst ``Std.BitVec) (toExpr w)
+
+instance : ToExpr BVBinPred where
+  toExpr x :=
+    match x with
+    | .eq => mkConst ``BVBinPred.eq
+  toTypeExpr := mkConst ``BVBinPred
+
+instance : ToExpr BVUnOp where
+  toExpr x :=
+    match x with
+    | .not => mkConst ``BVUnOp.not
+  toTypeExpr := mkConst ``BVUnOp
+
+instance : ToExpr BVBinOp where
+  toExpr x :=
+    match x with
+    | .and => mkConst ``BVBinOp.and
+  toTypeExpr := mkConst ``BVBinOp
+
+instance : ToExpr (BVExpr w) where
+  toExpr x := go x
+  toTypeExpr := mkApp (mkConst ``BVExpr) (toExpr w)
+where
+  go : BVExpr w → Expr
+| .var idx => mkApp (mkConst ``BVExpr.var) (toExpr idx)
+| .const val => mkApp (mkConst ``BVExpr.const) (toExpr val)
+| .bin lhs op rhs => mkApp3 (mkConst ``BVExpr.bin) (go lhs) (toExpr op) (go rhs)
+| .un op operand => mkApp2 (mkConst ``BVExpr.un) (toExpr op) (go operand)
+
+instance : ToExpr BVPred where
+  toExpr x := go x
+  toTypeExpr := mkConst ``BVPred
+where
+  go : BVPred → Expr
+  | .bin lhs op rhs => mkApp3 (mkConst ``BVPred.bin) (toExpr lhs) (toExpr op) (toExpr rhs)
+
+instance : ToExpr BVLogicalExpr where
+  toExpr x := go x
+  toTypeExpr := mkConst ``BVLogicalExpr
+where
+  go : BVLogicalExpr → Expr
+  | .literal pred => mkApp2 (mkConst ``BoolExpr.literal) (toTypeExpr BVPred) (toExpr pred)
+  | .const b => mkApp2 (mkConst ``BoolExpr.const) (toTypeExpr BVPred) (toExpr b)
+  | .not x => mkApp2 (mkConst ``BoolExpr.not) (toTypeExpr BVPred) (go x)
+  | .gate g x y => mkApp4 (mkConst ``BoolExpr.gate) (toTypeExpr BVPred) (toExpr g) (go x) (go y)
+
+
+structure State where
+  /--
+  The atoms encountered so far. Saved as a map from `BitVec` expressions to a
+  width × atomNumber pair.
+  -/
+  atoms : HashMap Expr (Nat × Nat) := {}
+
+abbrev M := StateRefT State MetaM
+
+namespace M
+
+def run (m : M α) : MetaM α :=
+  m.run' { } { }
+
+/-- Retrieve the atoms. -/
+def atoms : M (List (Nat × Expr)) :=
+  return (← getThe State).atoms.toArray.qsort (·.2.2 < ·.2.2) |>.map (fun (expr, width, _) => (width, expr)) |>.toList
+
+def atomsAssignment : M Expr := do
+  let as ← atoms
+  let packed : List Expr := as.map (fun (width, expr) => mkApp2 (mkConst ``BVExpr.PackedBitVec.mk) (toExpr width) expr)
+  let packedType := mkConst ``BVExpr.PackedBitVec
+  mkListLit packedType packed
+
+end M
+
+-- TODO: how to extract nat literals? Is there code for this?
+def parseNatLit (w : Expr) : Nat := sorry
+
+structure BVAtAtoms (w : Nat) where
+  bvExpr : BVExpr w
+  evalsAtAToms : M Expr
+  expr : Expr -- `toExpr bvExpr`, cached
+
+namespace BVAtAtoms
+
+def of (x : Expr) : M (Option (BVAtAtoms w)) := do
+  match x.getAppFnArgs with
+  | (``Std.BitVec.ofNat, #[_, valExpr]) =>
+    let val := parseNatLit valExpr
+    let bvVal := Std.BitVec.ofNat w val
+    let bvExpr := .const (Std.BitVec.ofNat w val)
+    let expr := mkApp2 (mkConst ``BVExpr.const) (toExpr w) (toExpr bvVal) 
+    -- Hopefully by rfl?
+    let proof := do sorry
+    return some ⟨bvExpr, proof, expr⟩
+  | _ => return none
+
+end BVAtAtoms
+
+structure HoldsAtAtoms (α : Type) where
+  bvExpr : α
+  holdsAtAtoms : M Expr -- a proof that `expr.eval atomsFn = true`
+  expr : Expr -- `toExpr bvExpr`, cached
+
+namespace HoldsAtAtoms
+
+-- TODO: we could store `evalFunc` in `HoldsAtAtoms` and maybe even fill it out with typeclass stuff
+def mkEvalExpr (evalFunc : Name) (expr : Expr) : M Expr := do
+  return mkApp2 (mkConst evalFunc) (← M.atomsAssignment) expr
+
+partial def of (h : Expr) : M (Option (HoldsAtAtoms BVLogicalExpr)) := do
+  -- TODO: naive approach, does not handle any boolean structure on top of our problem
+  -- this is no issue for most cases but we *must* handle at least negation of preds
+  -- for any proof by contradiction where the goal involves a bitvec expression.
+  let some pred ← ofPred h | return none
+  let bvExpr := .literal pred.bvExpr
+  let expr := mkApp2 (mkConst ``BoolExpr.literal) (mkConst ``BVPred) pred.expr
+  let proof := do
+    let evalLogic ← mkEvalExpr ``BVLogicalExpr.eval expr
+    let evalPred ← mkEvalExpr ``BVPred.eval expr
+    let helper := mkApp2 (mkConst ``Eq.refl [1]) (mkConst ``Bool) evalLogic
+    return mkApp6 (mkConst ``Eq.trans [1])
+      (mkConst ``Bool)
+      evalLogic
+      evalPred
+      (mkConst ``Bool.true)
+      helper
+      (← pred.holdsAtAtoms)
+  return some ⟨bvExpr, proof, expr⟩
+where
+  ofPred (h : Expr) : M (Option (HoldsAtAtoms BVPred)) := do
+    let t ← instantiateMVars (← whnfR (← inferType h))
+    match t.getAppFnArgs with
+    | (``Eq, #[.app (.const ``Std.BitVec []) widthExpr, lhs, rhs]) => 
+      let width := parseNatLit widthExpr
+      IO.println lhs
+      IO.println rhs
+      let some lhs ← BVAtAtoms.of lhs | return none
+      let some rhs ← BVAtAtoms.of rhs | return none
+      let bvExpr := .bin (w := width) lhs.bvExpr .eq rhs.bvExpr
+      let expr := mkApp4 (mkConst ``BVPred.bin) widthExpr lhs.expr (mkConst ``BVBinPred.eq) rhs.expr
+      /-
+        TODO: This will become a proof that evaluating this predicate holds through a congruence argument:
+        - h is of the form bv1 = bv2 
+        - we obtain proof from the parsing of bv1 and bv2 that evaluating their expressions (call them bv1' bv2')
+          is equivalent to bv1 and bv2 respectively
+        - we need a theorem that says (bv1 = bv2) (bv1 = bv1') (bv2 = bv2') : bv1' = bv2'
+        - apply this theorem on h and the lemmas from the parsed BV expressions
+      -/
+      let proof := do sorry
+      return some ⟨bvExpr, proof, expr⟩
+    | _ => return none
+
+def trivial : HoldsAtAtoms BVLogicalExpr where
+  bvExpr := .const true
+  expr := toExpr (.const true : BVLogicalExpr)
+  holdsAtAtoms := return mkApp (mkConst ``BVLogicalExpr.sat_true) (← M.atomsAssignment)
+
+def and (x y : HoldsAtAtoms BVLogicalExpr) : HoldsAtAtoms BVLogicalExpr where
+  bvExpr := .gate .and x.bvExpr y.bvExpr
+  expr := mkApp4 (mkConst ``BoolExpr.gate) (mkConst ``BVPred) (mkConst ``Gate.and) x.expr y.expr
+  holdsAtAtoms :=
+    return mkApp5 
+      (mkConst ``BVLogicalExpr.sat_and)
+      x.expr
+      y.expr
+      (← M.atomsAssignment)
+      (← x.holdsAtAtoms)
+      (← y.holdsAtAtoms)
+
+/-- Given a proof that `x.expr.unsat`, produce a proof of `False`. -/
+def proveFalse (x : HoldsAtAtoms BVLogicalExpr) (h : Expr) : M Expr := do
+  let atomsList ← M.atomsAssignment
+  let evalExpr := mkApp2 (mkConst ``BVLogicalExpr.eval) atomsList x.expr
+  return mkApp3 
+    (mkConst ``ReflectSat.SatAtAtoms.false_of_eq_true_of_eq_false)
+    evalExpr
+    (← x.holdsAtAtoms)
+    (.app h atomsList)
+
+end HoldsAtAtoms
+
+/--
+Given a goal `g`, which should be `False`, returns
+* a `e : BVLogicalExpr` (representing the conjunction of all bitvec predicates in hypotheses of `g`)
+* a function which takes an expression representing a proof of `e.unsat`,
+  and returns a proof of `False` valid in the context of `g`.
+-/
+def reflectBV (g : MVarId) : M (BVLogicalExpr × (Expr → M Expr)) := g.withContext do
+  let hyps ← getLocalHyps
+  let sats ← hyps.filterMapM HoldsAtAtoms.of
+  let sat := sats.foldl (init := HoldsAtAtoms.trivial) HoldsAtAtoms.and
+  return (sat.bvExpr, sat.proveFalse)
+
+def _root_.Lean.MVarId.bvDecide (g : MVarId) (cfg : SatDecide.TacticContext) : MetaM Unit := M.run do
+  let g' ← falseOrByContra g
+  g'.withContext do
+    let (bvLogicalExpr, f) ←
+      withTraceNode `bv (fun _ => return "Reflecting goal into BVLogicalExpr") do
+        reflectBV g'
+    trace[bv] "Reflected bv logical expression: {bvLogicalExpr}"
+    let aux := mkApp (mkConst ``BVLogicalExpr.unsat) (toExpr bvLogicalExpr)
+    let unsatProof := mkApp2 (mkConst ``sorryAx [.zero]) aux (mkConst ``Bool.false)
+    let proveFalse ← f unsatProof
+    g'.assign proveFalse
+
+syntax (name := bvDecideSyntax) "bv_decide" : tactic
+
+end BVDecide
+
+open Elab.Tactic
+elab_rules : tactic
+  | `(tactic| bv_decide) => do
+    let cfg ← SatDecide.TacticContext.new
+    liftMetaFinishingTactic fun g => g.bvDecide cfg

--- a/LeanSAT/Reflect/Tactics/Reflect.lean
+++ b/LeanSAT/Reflect/Tactics/Reflect.lean
@@ -53,7 +53,6 @@ def stashedAtomsFn : M Expr := do
 /--
 Look up an expression in the atoms, recording it if it has not previously appeared.
 -/
--- TODO use a hash map here, and don't use `isDefEq`.
 def lookup (e : Expr) : M Nat := do
   let c ← getThe State
   match c.atoms.find? e with

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -1,0 +1,36 @@
+import LeanSAT.Reflect.Tactics.BVDecide
+import Std.Data.BitVec.Basic
+
+open Std BitVec
+
+
+/-
+BVExpr w ↔ Std.BitVec w
+BVPred ↔ `Prop` that comes from predicates on `Std.BitVec`s
+BVLogicalExpr ↔ logical structure on top of `Prop`s represented by `BVPred`
+
+
+First approximation of tactic:
+- Do not handle anything on the BVLogicalExpr level apart from literals of BVPred
+- Handle only equality of Std.BitVec at a BVPred level
+- Handle only constants on BVExpr level
+
+next extensions:
+- Add support for negation at BVLogicalExpr level
+- Handle variables at BVExpr
+- Handle bitwise and at BVExpr
+- Handle bitwise not at BVExpr
+-/
+
+example (h : 0#1 = 1#1) : False := by bv_decide
+
+/-
+I now have to write a meta program that uses `h` to:
+1. translate it into `expr : BVLogicalExpr := .literal (.bin (.const 0#1) .eq (.const 1#1))`
+2. Show that expr.eval [] = true
+
+Concrete idea for doing this for the general `.literal case`:
+1. Hand the expression over to a parser that created the `BVPred`
+2. + returns a proof that `pred.eval [] = true`
+3. Based on that we should be trivially be able to show that `.literal bvpred` evaluates to true
+-/

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -20,7 +20,7 @@ next extensions:
 - Handle bitwise not at BVExpr
 -/
 
-theorem foo (h : 0#1 = 1#1) : False := by bv_decide
+theorem foo (h1 : 0#1 = 1#1) (h2 : (1 : BitVec 2) = 1) : False := by bv_decide
 
 #print foo
 

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -1,8 +1,6 @@
 import LeanSAT.Reflect.Tactics.BVDecide
-import Std.Data.BitVec.Basic
 
-open Std BitVec
-
+open BitVec
 
 /-
 BVExpr w ↔ Std.BitVec w
@@ -22,15 +20,8 @@ next extensions:
 - Handle bitwise not at BVExpr
 -/
 
-example (h : 0#1 = 1#1) : False := by bv_decide
+theorem foo (h : 0#1 = 1#1) : False := by bv_decide
 
-/-
-I now have to write a meta program that uses `h` to:
-1. translate it into `expr : BVLogicalExpr := .literal (.bin (.const 0#1) .eq (.const 1#1))`
-2. Show that expr.eval [] = true
+#print foo
 
-Concrete idea for doing this for the general `.literal case`:
-1. Hand the expression over to a parser that created the `BVPred`
-2. + returns a proof that `pred.eval [] = true`
-3. Based on that we should be trivially be able to show that `.literal bvpred` evaluates to true
--/
+

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -2,29 +2,11 @@ import LeanSAT.Reflect.Tactics.BVDecide
 
 open BitVec
 
-/-
-BVExpr w ↔ Std.BitVec w
-BVPred ↔ `Prop` that comes from predicates on `Std.BitVec`s
-BVLogicalExpr ↔ logical structure on top of `Prop`s represented by `BVPred`
-
-
-First approximation of tactic:
-- Do not handle anything on the BVLogicalExpr level apart from literals of BVPred
-- Handle only equality of Std.BitVec at a BVPred level
-- Handle only constants on BVExpr level
-
-next extensions:
-- Add support for negation at BVLogicalExpr level
-- Handle variables at BVExpr
-- Handle bitwise and at BVExpr
-- Handle bitwise not at BVExpr
--/
-
 set_option trace.bv true in
 theorem foo (h1 : 0#1 = 1#1) (h2 : (2 : BitVec 2) = 3) (h3 : x = 4#3)
     (h4 : x &&& y = y &&& x) : 4#5 = 5#5 := by
   bv_decide
 
 set_option trace.bv true in
-theorem all_features {x y : BitVec 10} (h : x = y) : x &&& 1 = y &&& 1#10 := by
+theorem all_features {x y : BitVec 10} (h : x = y) : (~~~x) &&& 1 = (~~~y) &&& 1#10 := by
   bv_decide

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -20,7 +20,7 @@ next extensions:
 - Handle bitwise not at BVExpr
 -/
 
-theorem foo (h1 : 0#1 = 1#1) (h2 : (1 : BitVec 2) = 1) : False := by bv_decide
+theorem foo (h1 : 0#1 = 1#1) (h2 : (1 : BitVec 2) = 1) (h3 : 0#1 ≠ 0#1) : 3#10 = 2#10 := by bv_decide
 
 #print foo
 

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -20,8 +20,11 @@ next extensions:
 - Handle bitwise not at BVExpr
 -/
 
-theorem foo (h1 : 0#1 = 1#1) (h2 : (1 : BitVec 2) = 1) (h3 : 0#1 ≠ 0#1) : 3#10 = 2#10 := by bv_decide
+set_option trace.bv true in
+theorem foo (h1 : 0#1 = 1#1) (h2 : (2 : BitVec 2) = 3) (h3 : x = 4#3)
+    (h4 : x &&& y = y &&& x) : 4#5 = 5#5 := by
+  bv_decide
 
-#print foo
-
-
+set_option trace.bv true in
+theorem all_features {x y : BitVec 10} (h : x = y) : x &&& 1 = y &&& 1#10 := by
+  bv_decide


### PR DESCRIPTION
Adds:
- A proof by reflection frontend for basic BitVec goals
- A bitblaster for the basic BitVec language

TODOs:
1. Implement AIGs such that we can share subterms, important for arithmetic
2. Change the basic bitblaster implementation to AIGs
3. Finish verifying the basic bitblaster
4. Extend the BitVec language