### PR TITLE
feat: add BitVec.or support to bv_decide

### DIFF
--- a/LeanSAT/Reflect/BVExpr/Basic.lean
+++ b/LeanSAT/Reflect/BVExpr/Basic.lean
@@ -7,18 +7,22 @@ import LeanSAT.Reflect.BoolExpr.Basic
 
 inductive BVBinOp where
 | and
+| or
 
 namespace BVBinOp
 
 def toString : BVBinOp → String
   | and => "&&"
+  | or => "||"
 
 instance : ToString BVBinOp := ⟨toString⟩
 
 def eval : BVBinOp → (BitVec w → BitVec w → BitVec w)
   | and => (· &&& ·)
+  | or => (· ||| ·)
 
 @[simp] theorem eval_and : eval .and = ((· &&& ·) : BitVec w → BitVec w → BitVec w) := by rfl
+@[simp] theorem eval_or : eval .or = ((· ||| ·) : BitVec w → BitVec w → BitVec w) := by rfl
 
 end BVBinOp
 

--- a/LeanSAT/Reflect/BVExpr/BitBlast.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlast.lean
@@ -207,27 +207,40 @@ where
             apply AIG.LawfulStreamOperator.le_size
         ⟩
     | .bin lhs op rhs =>
-      match op with
-      | .and =>
-        match go aig lhs with
-        | ⟨⟨laig, lhs⟩, hlaig⟩ =>
-          match go laig rhs with
-          | ⟨⟨raig, rhs⟩, hraig⟩ =>
-            let lhs := lhs.cast <| by
-              dsimp at hlaig hraig
-              omega
-            match hfinal:AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkAndCached⟩ with
-            | ⟨finalAig, s⟩ =>
-              ⟨
-                ⟨finalAig, s⟩,
-                by
-                  have : finalAig = (AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkAndCached⟩).aig := by
-                    simp [hfinal]
-                  simp only [this]
-                  apply AIG.LawfulStreamOperator.le_size_of_le_aig_size
-                  dsimp at hlaig hraig
-                  omega
-              ⟩
+      match go aig lhs with
+      | ⟨⟨laig, lhs⟩, hlaig⟩ =>
+        match go laig rhs with
+        | ⟨⟨raig, rhs⟩, hraig⟩ =>
+          let lhs := lhs.cast <| by
+            dsimp at hlaig hraig
+            omega
+          match op with
+          | .and =>
+             match hfinal:AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkAndCached⟩ with
+             | ⟨finalAig, s⟩ =>
+               ⟨
+                 ⟨finalAig, s⟩,
+                 by
+                   have : finalAig = (AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkAndCached⟩).aig := by
+                     simp [hfinal]
+                   simp only [this]
+                   apply AIG.LawfulStreamOperator.le_size_of_le_aig_size
+                   dsimp at hlaig hraig
+                   omega
+               ⟩
+          | .or =>
+             match hfinal:AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkOrCached⟩ with
+             | ⟨finalAig, s⟩ =>
+               ⟨
+                 ⟨finalAig, s⟩,
+                 by
+                   have : finalAig = (AIG.RefStream.zip raig ⟨lhs, rhs, AIG.mkOrCached⟩).aig := by
+                     simp [hfinal]
+                   simp only [this]
+                   apply AIG.LawfulStreamOperator.le_size_of_le_aig_size
+                   dsimp at hlaig hraig
+                   omega
+               ⟩
     | .un op expr =>
       match op with
       | .not =>
@@ -271,8 +284,32 @@ theorem bitblast.go_decl_eq? (aig : AIG BVBit) (expr : BVExpr w)
       assumption
     . assumption
   | bin lhs op rhs lih rih =>
+    -- TODO: Proof dedup
     cases op with
     | and =>
+      dsimp [go]
+      rw [Array.getElem?_lt, Array.getElem?_lt]
+      rw [AIG.LawfulStreamOperator.decl_eq]
+      rw [← Array.getElem?_lt, ← Array.getElem?_lt]
+      rw [rih, lih]
+      -- TODO: for some reason my usual omega attempts fail me here
+      . assumption
+      . apply Nat.lt_of_lt_of_le
+        . exact hidx
+        . exact (bitblast.go aig lhs).property
+      . assumption
+      . apply Nat.lt_of_lt_of_le
+        . exact hidx
+        . apply Nat.le_trans
+          . exact (bitblast.go aig lhs).property
+          . exact (go (go aig lhs).1.aig rhs).property
+      . apply AIG.LawfulStreamOperator.lt_size_of_lt_aig_size
+        apply Nat.lt_of_lt_of_le
+        . exact hidx
+        . apply Nat.le_trans
+          . exact (bitblast.go aig lhs).property
+          . exact (go (go aig lhs).1.aig rhs).property
+    | or =>
       dsimp [go]
       rw [Array.getElem?_lt, Array.getElem?_lt]
       rw [AIG.LawfulStreamOperator.decl_eq]

--- a/LeanSAT/Reflect/BVExpr/BitBlastLemmas.lean
+++ b/LeanSAT/Reflect/BVExpr/BitBlastLemmas.lean
@@ -241,6 +241,13 @@ theorem go_denote_eq_eval_getLsb (aig : AIG BVBit) (expr : BVExpr w) (assign : A
       rw [AIG.LawfulStreamOperator.denote_input_stream (f := bitblast)]
       rw [← go_val_eq_bitblast]
       rw [lih]
+    | or =>
+      simp only [go, RefStream.denote_zip, denote_mkOrCached, rih, eval_bin, BVBinOp.eval_or,
+        BitVec.getLsb_or]
+      simp only [go_val_eq_bitblast, RefStream.getRef_cast]
+      rw [AIG.LawfulStreamOperator.denote_input_stream (f := bitblast)]
+      rw [← go_val_eq_bitblast]
+      rw [lih]
   | un op expr ih =>
     cases op with
     | not => simp [go, ih, hidx]

--- a/Test/Bv.lean
+++ b/Test/Bv.lean
@@ -3,12 +3,16 @@ import LeanSAT.Reflect.Tactics.BVDecide
 open BitVec
 
 set_option trace.bv true in
-theorem foo (h1 : 0#1 = 1#1) (h2 : (2 : BitVec 2) = 3) (h3 : x = 4#3)
+theorem unit_1 (h1 : 0#1 = 1#1) (h2 : (2 : BitVec 2) = 3) (h3 : x = 4#3)
     (h4 : x &&& y = y &&& x) : 4#5 = 5#5 := by
   bv_decide
 
 set_option trace.bv true in
-theorem all_features {x y : BitVec 256} (h : x = y) : (~~~x) &&& 1 = (~~~y) &&& 1#256 := by
+theorem unit_2 {x y : BitVec 256} (h : x = y) : (~~~x) &&& 1 = (~~~y) &&& 1#256 := by
+  bv_decide
+
+set_option trace.bv true in
+theorem unit_3 {x y : BitVec 256} : ~~~(x &&& y) = (~~~x ||| ~~~y) := by
   bv_decide
 
 theorem bv_axiomCheck (x : BitVec 1) : x = x := by bv_decide


### PR DESCRIPTION
Based on #40. Mostly a demonstration of how simple it is to add bitwise ops with this.